### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/Base64/keywords.txt
+++ b/Base64/keywords.txt
@@ -7,16 +7,16 @@
 #######################################
 
 # I WANT BASE64.h HIGHLIGHTED, DAMMIT!
-Base64		KEYWORD1
+Base64	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-base64_encode 	KEYWORD2
-base64_decode 	KEYWORD2
-base64_enc_len 	KEYWORD2
-base64_dec_len 	KEYWORD2
+base64_encode	KEYWORD2
+base64_decode	KEYWORD2
+base64_enc_len	KEYWORD2
+base64_dec_len	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords